### PR TITLE
Make executable

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const { Project, ts } = require("ts-morph");
 const { cwd } = require('process')
 const path = require('path')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "demake-dts",
+  "name": "downlevel-dts",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "demake-dts",
+  "name": "downlevel-dts",
   "version": "1.0.0",
   "description": "Convert d.ts to be compatible with older typescript compilers",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Convert d.ts to be compatible with older typescript compilers",
   "main": "index.js",
+  "bin": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
This PR makes the package usable as an "executable" by adding a `bin` entry to `package.json` and a shebang line to `index.js`, as per [npm docs](https://docs.npmjs.com/files/package.json#bin).

I also noticed that the package name and version do not match [the published package on npm](https://www.npmjs.com/package/downlevel-dts)? I've fixed the package name so it would properly publish as `downlevel-dts`, but I'm not sure what to do with the version number. 🤷‍♂