### PR TITLE
Switch to typescript

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+baselines/

--- a/baselines/ts3.4/src/test.d.ts
+++ b/baselines/ts3.4/src/test.d.ts
@@ -1,12 +1,12 @@
 export class C {
-    p: number
-    readonly q: string
-    r: boolean
+  p: number;
+  readonly q: string;
+  r: boolean;
 }
 export namespace N {
-    class D {
-        p: number
-        readonly q: string
-        r: boolean
-    }
+  class D {
+    p: number;
+    readonly q: string;
+    r: boolean;
+  }
 }

--- a/baselines/ts3.4/src/test.d.ts
+++ b/baselines/ts3.4/src/test.d.ts
@@ -1,12 +1,12 @@
 export class C {
-  p: number;
-  readonly q: string;
-  r: boolean;
-}
-export namespace N {
-  class D {
     p: number;
     readonly q: string;
     r: boolean;
-  }
+}
+export namespace N {
+    class D {
+        p: number;
+        readonly q: string;
+        r: boolean;
+    }
 }

--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -1,12 +1,12 @@
 export class C {
-    p: number
-    readonly q: string
-    r: boolean
+  protected p: number;
+  public readonly q: string;
+  private r: boolean;
 }
 export namespace N {
-    class D {
-        p: number
-        readonly q: string
-        r: boolean
-    }
+  abstract class D {
+    p: number;
+    readonly q: any;
+    abstract r: boolean;
+  }
 }

--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -1,12 +1,12 @@
 export class C {
-  protected p: number;
-  public readonly q: string;
-  private r: boolean;
+    protected p: number;
+    public readonly q: string;
+    private r: boolean;
 }
 export namespace N {
-  abstract class D {
-    p: number;
-    readonly q: any;
-    abstract r: boolean;
-  }
+    abstract class D {
+        p: number;
+        readonly q: any;
+        abstract r: boolean;
+    }
 }

--- a/index.js
+++ b/index.js
@@ -24,9 +24,9 @@ function doTransform(k) {
         n.decorators,
         modifiers,
         n.name,
-        undefined,
+        /*?! token*/ undefined,
         defaultAny(n.type),
-        undefined
+        /*initialiser*/ undefined
       );
     } else if (ts.isSetAccessor(n)) {
       if (getMatchingAccessor(n, "set")) {
@@ -37,9 +37,9 @@ function doTransform(k) {
           n.decorators,
           n.modifiers,
           n.name,
-          undefined,
+          /*?! token*/ undefined,
           defaultAny(n.parameters[0].type),
-          undefined
+          /*initialiser*/ undefined
         );
       }
     }
@@ -52,7 +52,11 @@ function doTransform(k) {
 function defaultAny(t) {
   return t || ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
 }
-/** @param {import("typescript").AccessorDeclaration} n @param {'get' | 'set'} getset */
+
+/**
+ * @param {import("typescript").AccessorDeclaration} n
+ * @param {'get' | 'set'} getset
+ */
 function getMatchingAccessor(n, getset) {
   if (!ts.isClassDeclaration(n.parent))
     throw new Error(

--- a/index.js
+++ b/index.js
@@ -1,79 +1,116 @@
 #!/usr/bin/env node
-
-const { Project, ts } = require("ts-morph");
+const sh = require("shelljs");
+const fs = require("fs");
+const ts = require("typescript");
 const path = require("path");
+const assert = require("assert");
 
+/** @typedef {import("typescript").Node} Node */
+
+/** @param {import("typescript").TransformationContext} k */
+function doTransform(k) {
+  /**
+   * @param {Node} n
+   * @return {Node}
+   */
+  const transform = function(n) {
+    if (ts.isGetAccessor(n)) {
+      let flags = ts.getCombinedModifierFlags(n);
+      if (!getMatchingAccessor(n, "get")) {
+        flags |= ts.ModifierFlags.Readonly;
+      }
+      const modifiers = ts.createModifiersFromModifierFlags(flags);
+      return ts.createProperty(
+        n.decorators,
+        modifiers,
+        n.name,
+        undefined,
+        defaultAny(n.type),
+        undefined
+      );
+    } else if (ts.isSetAccessor(n)) {
+      if (getMatchingAccessor(n, "set")) {
+        return /** @type {*} */ (undefined);
+      } else {
+        assert(n.parameters && n.parameters.length);
+        return ts.createProperty(
+          n.decorators,
+          n.modifiers,
+          n.name,
+          undefined,
+          defaultAny(n.parameters[0].type),
+          undefined
+        );
+      }
+    }
+    return ts.visitEachChild(n, transform, k);
+  };
+  return transform;
+}
+
+/** @param {import("typescript").TypeNode | undefined} t */
+function defaultAny(t) {
+  return t || ts.createKeywordTypeNode(ts.SyntaxKind.AnyKeyword);
+}
+/** @param {import("typescript").AccessorDeclaration} n @param {'get' | 'set'} getset */
+function getMatchingAccessor(n, getset) {
+  if (!ts.isClassDeclaration(n.parent))
+    throw new Error(
+      "Bad AST -- accessor parent should be a class declaration."
+    );
+  const isOther = getset === "get" ? ts.isSetAccessor : ts.isGetAccessor;
+  return n.parent.members.some(
+    m => isOther(m) && m.name.getText() === n.name.getText()
+  );
+}
 /**
  * @param {string} src
  * @param {string} target
  */
-async function main(src, target) {
+function main(src, target) {
   if (!src || !target) {
-    console.log("Usage: node ../index.js . ts3.4");
+    console.log("Usage: node index.js test test/ts3.4");
     process.exit(1);
   }
-  const project = new Project({
-    tsConfigFilePath: path.join(src, "tsconfig.json")
-  });
-  const targetDir = project.createDirectory(target);
 
-  for (const f of project.getSourceFiles("**/*.d.ts")) {
-    if (f.isInNodeModules()) {
-      continue;
-    }
-    const newFile = targetDir.createSourceFile(
-      project.getDirectoryOrThrow(src).getRelativePathTo(f),
-      f.getFullText(),
-      { overwrite: true }
-    );
-    const gs = newFile.getDescendantsOfKind(ts.SyntaxKind.GetAccessor);
-    for (const g of gs) {
-      const s = g.getSetAccessor();
-      const returnTypeNode = g.getReturnTypeNode();
-      g.replaceWithText(
-        `${getModifiersText(g)}${
-          s ? "" : "readonly "
-        }${g.getName()}: ${(returnTypeNode && returnTypeNode.getText()) ||
-          "any"}`
-      );
-      if (s) {
-        s.remove();
-      }
-    }
-    const ss = newFile.getDescendantsOfKind(ts.SyntaxKind.SetAccessor);
-    for (const s of ss) {
-      const g = s.getGetAccessor();
-      if (!g) {
-        const firstParam = s.getParameters()[0];
-        const paramTypeNode = firstParam && firstParam.getTypeNode();
-        s.replaceWithText(
-          `${getModifiersText(s)}${s.getName()}: ${(paramTypeNode &&
-            paramTypeNode.getText()) ||
-            "any"}`
-        );
-      }
-    }
+  // TODO: target path is probably wrong for absolute src (or target?)
+  // TODO: Probably will want to alter package.json if discovered in the right place.
+  const program = ts.createProgram(
+    sh
+      .find(path.join(src))
+      .filter(f => f.endsWith(".d.ts") && !/node_modules/.test(f)),
+    {}
+  );
+  const checker = program.getTypeChecker(); // just used for setting parent pointers right now
+  const files = mapDefined(program.getRootFileNames(), program.getSourceFile);
+  const resultat = ts.transform(files, [doTransform]);
+  const printer = ts.createPrinter();
+  for (const t of resultat.transformed) {
+    const f = /** @type {import("typescript").SourceFile} */ (t);
+    const targetPath = path.join(target, f.fileName.slice(src.length));
+    sh.mkdir("-p", path.dirname(targetPath));
+    fs.writeFileSync(targetPath, printer.printFile(f));
   }
-  await targetDir.save();
-}
-
-/**
- * @param {import("ts-morph").ModifierableNode} node
- */
-function getModifiersText(node) {
-  const modifiersText = node
-    .getModifiers()
-    .map(m => m.getText())
-    .join(" ");
-  return modifiersText.length > 0 ? modifiersText + " " : "";
 }
 module.exports.main = main;
 
-if (!(/** @type {*} */ (module).parent)) {
+if (!(/** @type {*} */ (module.parent))) {
   const src = process.argv[2];
   const target = process.argv[3];
-  main(src, target).catch(e => {
-    console.log(e);
-    process.exit(1);
-  });
+  main(src, target);
+}
+
+/**
+ * @template T,U
+ * @param {readonly T[]} l
+ * @param {(t: T) => U | false | undefined} f
+ * @return {U[]}
+ */
+function mapDefined(l, f) {
+  const acc = [];
+  for (const x of l) {
+    const y = f(x);
+    if (y) acc.push(y);
+  }
+  return acc;
 }

--- a/index.js
+++ b/index.js
@@ -88,7 +88,9 @@ function main(src, target) {
   const checker = program.getTypeChecker(); // just used for setting parent pointers right now
   const files = mapDefined(program.getRootFileNames(), program.getSourceFile);
   const resultat = ts.transform(files, [doTransform]);
-  const printer = ts.createPrinter();
+  const printer = ts.createPrinter({
+    newLine: ts.NewLineKind.CarriageReturnLineFeed
+  });
   for (const t of resultat.transformed) {
     const f = /** @type {import("typescript").SourceFile} */ (t);
     const targetPath = path.join(target, f.fileName.slice(src.length));

--- a/index.test.js
+++ b/index.test.js
@@ -1,24 +1,29 @@
-const { main } = require("./index")
-const fs = require("fs")
-const path = require("path")
+const { main } = require("./index");
+const sh = require("shelljs");
+const fs = require("fs");
+const path = require("path");
 /**
  * @param {string} description
  * @param {{ [s: string]: () => void }} tests
  */
 function suite(description, tests) {
-    describe(description, () => {
-        for (const k in tests) {
-            test(k, tests[k], 10 * 1000)
-        }
-    })
+  describe(description, () => {
+    for (const k in tests) {
+      test(k, tests[k], 10 * 1000);
+    }
+  });
 }
 suite("main", {
-    async works() {
-        if (fs.existsSync("test/ts3.4")) {
-            fs.rmdirSync("test/ts3.4", { recursive: true })
-        }
-        await main("test", "test/ts3.4")
-        expect(fs.readFileSync("baselines/ts3.4/test.d.ts", "utf8")).toEqual(fs.readFileSync("test/ts3.4/test.d.ts", "utf8"))
-        expect(fs.readFileSync("baselines/ts3.4/src/test.d.ts", "utf8")).toEqual(fs.readFileSync("test/ts3.4/src/test.d.ts", "utf8"))
-    },
-})
+  works() {
+    if (fs.existsSync("test/ts3.4")) {
+      sh.rm("-r", "test/ts3.4");
+    }
+    main("test", "test/ts3.4");
+    expect(fs.readFileSync("baselines/ts3.4/test.d.ts", "utf8")).toEqual(
+      fs.readFileSync("test/ts3.4/test.d.ts", "utf8")
+    );
+    expect(fs.readFileSync("baselines/ts3.4/src/test.d.ts", "utf8")).toEqual(
+      fs.readFileSync("test/ts3.4/src/test.d.ts", "utf8")
+    );
+  }
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -225,15 +225,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@dsherret/to-absolute-glob": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dsherret/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
-      "integrity": "sha1-H2R13IvZdM6gei2vOGSzF7HdMyw=",
-      "requires": {
-        "is-absolute": "^1.0.0",
-        "is-negated-glob": "^1.0.0"
-      }
-    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -640,42 +631,6 @@
         "@types/yargs": "^13.0.0"
       }
     },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
-      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
-      "requires": {
-        "@nodelib/fs.stat": "2.0.3",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
-      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.3",
-        "fastq": "^1.6.0"
-      }
-    },
-    "@ts-morph/common": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.2.2.tgz",
-      "integrity": "sha512-cMUlKTWvrfE5RYJn2VvM67iwIPl3aXm4xfm8oHzCCi2YaWp+NlSuiqj5cUMh+Lse2y84BqjAVOxAv1AY1Ncf+w==",
-      "requires": {
-        "@dsherret/to-absolute-glob": "^2.0.2",
-        "fast-glob": "^3.1.0",
-        "fs-extra": "^8.1.0",
-        "is-negated-glob": "^1.0.0",
-        "multimatch": "^4.0.0",
-        "typescript": "~3.7.2"
-      }
-    },
     "@types/babel__core": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.3.tgz",
@@ -723,6 +678,23 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
@@ -751,13 +723,29 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "13.1.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.6.tgz",
+      "integrity": "sha512-Jg1F+bmxcpENHP23sVKkNuU3uaxPnsBMW0cLjleiikFKomJQbsn0Cqk2yDvQArqzZN6ABfBkZ0To7pQ8sLdWDg=="
     },
     "@types/parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
+    },
+    "@types/shelljs": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.6.tgz",
+      "integrity": "sha512-svx2eQS268awlppL/P8wgDLBrsDXdKznABHJcuqXyWpSKJgE1s2clXlBvAwbO/lehTmG06NtEWJRkAk4tAgenA==",
+      "dev": true,
+      "requires": {
+        "@types/glob": "*",
+        "@types/node": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -985,7 +973,8 @@
     "array-differ": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
-      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg=="
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
@@ -996,7 +985,8 @@
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1007,7 +997,8 @@
     "arrify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "dev": true
     },
     "asn1": {
       "version": "0.2.4",
@@ -1208,14 +1199,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
     "browser-process-hrtime": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/browser-process-hrtime/-/browser-process-hrtime-0.1.3.tgz",
@@ -1354,11 +1337,6 @@
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
-    },
-    "code-block-writer": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.0.tgz",
-      "integrity": "sha512-RG9hpXtWFeUWhuUav1YuP/vGcyncW+t90yJLk9fNZs1De2OuHTHKAKThVCokt29PYq5RoJ0QSZaIZ+rvPO23hA=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1906,18 +1884,6 @@
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
-    "fast-glob": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
-      "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.2"
-      }
-    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1929,14 +1895,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
-    },
-    "fastq": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.6.0.tgz",
-      "integrity": "sha512-jmxqQ3Z/nXoeyDmWAzF9kH1aGZSis6e/SbfPmJpUnyZ0ogr6iscHQaml4wsEepEWSdtmpy+eVXmCRIMpxaXqOA==",
-      "requires": {
-        "reusify": "^1.0.0"
-      }
     },
     "fb-watchman": {
       "version": "2.0.1",
@@ -1953,14 +1911,6 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "dev": true,
       "optional": true
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
     },
     "find-up": {
       "version": "3.0.0",
@@ -2003,21 +1953,10 @@
         "map-cache": "^0.2.2"
       }
     },
-    "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.11",
@@ -2623,7 +2562,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2631,14 +2569,6 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-      "integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
-      "requires": {
-        "is-glob": "^4.0.1"
       }
     },
     "globals": {
@@ -2650,7 +2580,8 @@
     "graceful-fs": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -2950,7 +2881,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2959,8 +2889,12 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -2969,15 +2903,6 @@
       "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
-      }
-    },
-    "is-absolute": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
-      "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
-      "requires": {
-        "is-relative": "^1.0.0",
-        "is-windows": "^1.0.1"
       }
     },
     "is-accessor-descriptor": {
@@ -3078,11 +3003,6 @@
       "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
       "dev": true
     },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
-    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
@@ -3094,24 +3014,6 @@
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
       "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-negated-glob": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
-      "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI="
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -3129,14 +3031,6 @@
       "dev": true,
       "requires": {
         "has": "^1.0.3"
-      }
-    },
-    "is-relative": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
-      "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
-      "requires": {
-        "is-unc-path": "^1.0.0"
       }
     },
     "is-stream": {
@@ -3160,18 +3054,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
-    "is-unc-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
-      "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
-      "requires": {
-        "unc-path-regex": "^0.1.2"
-      }
-    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -4141,14 +4028,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "requires": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4292,20 +4171,6 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
-    "merge2": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-      "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
-    },
-    "micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-      "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.0.5"
-      }
-    },
     "mime-db": {
       "version": "1.43.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
@@ -4395,6 +4260,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
       "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+      "dev": true,
       "requires": {
         "@types/minimatch": "^3.0.3",
         "array-differ": "^3.0.0",
@@ -4601,7 +4467,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -4738,8 +4603,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-key": {
       "version": "2.0.1",
@@ -4750,8 +4614,7 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "4.0.0",
@@ -4764,11 +4627,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
-    },
-    "picomatch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
-      "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA=="
     },
     "pify": {
       "version": "3.0.0",
@@ -5062,6 +4920,14 @@
         "util.promisify": "^1.0.0"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
@@ -5178,7 +5044,6 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
       "integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
-      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -5210,11 +5075,6 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
     },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
-    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -5229,11 +5089,6 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true
-    },
-    "run-parallel": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-      "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -5439,6 +5294,16 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "shellwords": {
       "version": "0.1.1",
@@ -5865,14 +5730,6 @@
         "safe-regex": "^1.1.0"
       }
     },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
     "tough-cookie": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
@@ -5890,16 +5747,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "ts-morph": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-6.0.2.tgz",
-      "integrity": "sha512-o7FPVY0jMSKlJHfyfEkiCWTq7vqdmNLQaQd4jXY7lxCELgh+h7zI+frvSe7S0o/TJAAKViy9wM/FzRXW+9LnZQ==",
-      "requires": {
-        "@dsherret/to-absolute-glob": "^2.0.2",
-        "@ts-morph/common": "~0.2.2",
-        "code-block-writer": "^10.1.0"
       }
     },
     "tunnel-agent": {
@@ -5927,9 +5774,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
-      "integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw=="
+      "version": "3.8.0-dev.20200111",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200111.tgz",
+      "integrity": "sha512-9LNK1LhRc7V5WA32tI9i2MDOYWz9DaTNb6TtWcR50trm0C2oA/FyuT/mxSbKZwrxh5becNhaehiR/sgDO64v0g=="
     },
     "uglify-js": {
       "version": "3.7.4",
@@ -5942,11 +5789,6 @@
         "source-map": "~0.6.1"
       }
     },
-    "unc-path-regex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
-    },
     "union-value": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -5958,11 +5800,6 @@
         "is-extendable": "^0.1.1",
         "set-value": "^2.0.1"
       }
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",
@@ -6159,8 +5996,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write-file-atomic": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -5,14 +5,18 @@
   "main": "index.js",
   "bin": "index.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "baseline-accept": "cp -r test/ts3.4 baselines"
   },
   "author": "Nathan Shively-Sanders",
   "license": "MIT",
   "dependencies": {
-    "ts-morph": "^6.0.2"
+    "shelljs": "^0.8.3",
+    "typescript": "^3.8.0-dev.20200111"
   },
   "devDependencies": {
+    "@types/node": "^13.1.6",
+    "@types/shelljs": "^0.8.6",
     "husky": "^4.0.0",
     "jest": "^24.9.0",
     "prettier": "^1.19.1",

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -1,14 +1,14 @@
 export class C {
-    get p(): number
-    set p(value: number)
-    get q(): string
-    set r(value: boolean)
+  protected get p(): number;
+  protected set p(value: number);
+  public get q(): string;
+  private set r(value: boolean);
 }
 export namespace N {
-    class D {
-        get p(): number
-        set p(value: number)
-        get q(): string
-        set r(value: boolean)
-    }
+  abstract class D {
+    get p(): number;
+    set p(value: number);
+    get q();
+    abstract set r(value: boolean);
+  }
 }


### PR DESCRIPTION
1. Switch to typescript so 3.8 API changes will be available.
2. Use sh.find instead of tsconfig to locate files since we'll usually be running on output files.
3. Add tests for previously untested code.
4. Add a baseline-accept script.