### PR TITLE
Work around triple slash duplication from Typescript

### DIFF
--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -1,10 +1,11 @@
-/// <reference types="node" />
+/// <reference path="./src/test.d.ts" />
 /// <reference types="node" />
 export class C {
     protected p: number;
     public readonly q: string;
     private r: boolean;
 }
+// hi, this should still be there
 export namespace N {
     abstract class D {
         p: number;

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -1,10 +1,12 @@
 /// <reference types="node" />
+/// <reference path="./src/test.d.ts" />
 export class C {
   protected get p(): number;
   protected set p(value: number);
   public get q(): string;
   private set r(value: boolean);
 }
+// hi, this should still be there
 export namespace N {
   abstract class D {
     get p(): number;


### PR DESCRIPTION
Fixes #12
Won't be needed after Microsoft/Typescript#36242 is fixed or has a better workaround.

Note that this PR may cause reordering of triple-slash references.