### PR TITLE
Transform Omit into the equivilant Pick type declaration

### DIFF
--- a/baselines/ts3.4/src/test.d.ts
+++ b/baselines/ts3.4/src/test.d.ts
@@ -11,3 +11,9 @@ export namespace N {
     }
 }
 export { C as DetectiveComics };
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Omit<E, 'a'>;

--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -16,3 +16,8 @@ export namespace N {
 import { C as CD } from "./src/test";
 import * as rex_1 from "./src/test";
 export { rex_1 as rex } from "./src/test";
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Pick<E, Exclude<keyof E, 'a'>>;

--- a/index.js
+++ b/index.js
@@ -130,8 +130,8 @@ function doTransform(checker, k) {
       const typeArguments = n.typeArguments;
 
       if (
-        symbol !== undefined &&
-        symbol.declarations.length > 0 &&
+        symbol &&
+        symbol.declarations.length &&
         symbol.declarations[0]
           .getSourceFile()
           .fileName.includes("node_modules/typescript/lib/lib") &&

--- a/index.js
+++ b/index.js
@@ -121,6 +121,16 @@ function doTransform(k) {
       );
     } else if (ts.isImportClause(n) && n.isTypeOnly) {
       return ts.createImportClause(n.name, n.namedBindings);
+    } else if (ts.isTypeReferenceNode(n) && n.typeName.escapedText === "Omit") {
+      const child = n.getChildAt(2);
+
+      return ts.createTypeReferenceNode(ts.createIdentifier("Pick"), [
+        child.getChildAt(0),
+        ts.createTypeReferenceNode(ts.createIdentifier("Exclude"), [
+          ts.createTypeOperatorNode(child.getChildAt(0)),
+          child.getChildAt(2)
+        ])
+      ]);
     }
     return ts.visitEachChild(n, transform, k);
   };

--- a/index.js
+++ b/index.js
@@ -125,7 +125,11 @@ function doTransform(checker, k) {
       );
     } else if (ts.isImportClause(n) && n.isTypeOnly) {
       return ts.createImportClause(n.name, n.namedBindings);
-    } else if (ts.isTypeReferenceNode(n) && n.typeName.escapedText === "Omit") {
+    } else if (
+      ts.isTypeReferenceNode(n) &&
+      ts.isIdentifier(n.typeName) &&
+      n.typeName.escapedText === "Omit"
+    ) {
       const symbol = checker.getSymbolAtLocation(n.typeName);
       const typeArguments = n.typeArguments;
 

--- a/index.js
+++ b/index.js
@@ -127,21 +127,21 @@ function doTransform(checker, k) {
       return ts.createImportClause(n.name, n.namedBindings);
     } else if (ts.isTypeReferenceNode(n) && n.typeName.escapedText === "Omit") {
       const symbol = checker.getSymbolAtLocation(n.typeName);
+      const typeArguments = n.typeArguments;
 
       if (
         symbol !== undefined &&
         symbol.declarations.length > 0 &&
         symbol.declarations[0]
           .getSourceFile()
-          .fileName.includes("node_modules/typescript/lib/lib")
+          .fileName.includes("node_modules/typescript/lib/lib") &&
+        typeArguments
       ) {
-        const child = n.getChildAt(2);
-
         return ts.createTypeReferenceNode(ts.createIdentifier("Pick"), [
-          child.getChildAt(0),
+          typeArguments[0],
           ts.createTypeReferenceNode(ts.createIdentifier("Exclude"), [
-            ts.createTypeOperatorNode(child.getChildAt(0)),
-            child.getChildAt(2)
+            ts.createTypeOperatorNode(typeArguments[0]),
+            typeArguments[1]
           ])
         ]);
       }

--- a/test/src/test.d.ts
+++ b/test/src/test.d.ts
@@ -14,3 +14,12 @@ export namespace N {
 }
 
 export type { C as DetectiveComics };
+
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+
+export interface E {
+  a: number;
+  b: number;
+}
+
+export type F = Omit<E, 'a'>;

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -18,3 +18,10 @@ export namespace N {
 import type { C as CD } from "./src/test";
 
 export * as rex from "./src/test";
+
+export interface E {
+  a: number;
+  b: number;
+}
+
+export type F = Omit<E, 'a'>;


### PR DESCRIPTION
This pull request aims to add the downlevel transformation of the Omit type. I basically cobbled it together by looking at the [ts-ast-viewer](https://ts-ast-viewer.com). One thing I struggled with is how to make sure that the Omit type at hand is actually the one from TypeScript and not some other user defined type which just has the same name.