### PR TITLE
Use sourceFile.path, not fileName

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ function main(src, target) {
   for (const t of ts.transform(files, [doTransform.bind(null, checker)])
     .transformed) {
     const f = /** @type {import("typescript").SourceFile} */ (t);
-    const targetPath = path.join(target, f.fileName.slice(src.length));
+    const targetPath = path.join(
+      target,
+      f.path.slice(path.resolve(src).length)
+    );
     sh.mkdir("-p", path.dirname(targetPath));
     fs.writeFileSync(targetPath, dedupeTripleSlash(printer.printFile(f)));
   }

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function main(src, target) {
     const f = /** @type {import("typescript").SourceFile} */ (t);
     const targetPath = path.join(
       target,
-      f.path.slice(path.resolve(src).length)
+      path.resolve(f.fileName).slice(path.resolve(src).length)
     );
     sh.mkdir("-p", path.dirname(targetPath));
     fs.writeFileSync(targetPath, dedupeTripleSlash(printer.printFile(f)));


### PR DESCRIPTION
Sometimes fileName is relative, sometime it is not. sourceFile.path, while internal, is always absolute.

Edit: Or I could just `path.resolve(f.fileName)` .

Fixes #11 