### PR TITLE
Change example to account for TS3.5 users and below

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ downlevelled, nor are there plans to support Typescript 2.x.
 
 ```json
 "typesVersions": {
-  "<=3.4.0-0": { "*": ["ts3.4/*"] }
+  "<=3.5": { "*": ["ts3.4/*"] }
 }
 ```
 


### PR DESCRIPTION
Thanks for updating the README, I think this will really help users that are adopting this (seems like there have been more downloads here recently!).

Instead of `<=3.4.0-0` like it says in the Usage section of the README it should really refer to `<=3.5`. If we just target <=3.4.0-0 like the example states, it could be misleading to some users of this library that aren't really keen on the recent changes. For example, with the version `<=3.4.0-0` a maintainer can use downlevel-dts, copy and paste this `typesVersions` in their package.json but their TS3.5 users will still get bit by the accessor output changes in TS3.7.