### PR TITLE
Downlevel readonly array & readonly tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ appropriate version of Typescript.
 
 Here is the list of features that are downlevelled:
 
+### ReadonlyArray and readonly tuples (3.4)
+
+```ts
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [string, number];
+```
+
+becomes
+
+```ts
+export declare let readonlyArr: ReadonlyArray<string>;
+export declare let readonlyTuple: Readonly<[string, number]>;
+```
+
 ### `Omit` (3.5)
 
 ```ts

--- a/baselines/reference/ts3.3/src/test.d.ts
+++ b/baselines/reference/ts3.3/src/test.d.ts
@@ -17,8 +17,8 @@ export interface E {
     b: number;
 }
 export type F = Omit<E, 'a'>;
-export declare let readonlyArr: readonly string[];
-export declare let readonlyTuple: readonly [
+export declare let readonlyArr: ReadonlyArray<string>;
+export declare let readonlyTuple: Readonly<[
     string,
     number
-];
+]>;

--- a/baselines/reference/ts3.3/test.d.ts
+++ b/baselines/reference/ts3.3/test.d.ts
@@ -1,0 +1,52 @@
+/// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+export class C {
+    protected p: number;
+    public readonly q: string;
+    private r: boolean;
+}
+// hi, this should still be there
+export namespace N {
+    abstract class D {
+        /*
+        * @readonly
+        * @memberof BlobLeaseClient
+        * @type {number}
+        
+        preserve this too */
+        p: number;
+        readonly q: any;
+        abstract r: boolean;
+    }
+}
+/** is this a single-line comment? */
+import { C as CD } from "./src/test";
+import * as rex_1 from "./src/test";
+//another comment
+export { rex_1 as rex };
+export interface E {
+    a: number;
+    b: number;
+}
+/// is this a single-line comment?
+export type F = Pick<E, Exclude<keyof E, 'a'>>;
+export class G {
+    private "G.#private";
+}
+export class H extends G {
+    private "H.#private";
+}
+export interface I extends Pick<E, Exclude<keyof E, 'a'>> {
+    version: number;
+}
+declare function guardIsString(val: any): val is string;
+/** side-effects! */
+declare function assertIsString(val: any, msg?: string): void;
+declare function assert(val: any, msg?: string): void;
+type J = [
+    /*foo*/ string,
+    /*bar*/ number,
+    /*arr*/ ...boolean[]
+];
+import * as default_1 from "./src/test";
+export { default_1 as default };

--- a/baselines/reference/ts3.5/src/test.d.ts
+++ b/baselines/reference/ts3.5/src/test.d.ts
@@ -17,3 +17,8 @@ export interface E {
     b: number;
 }
 export type F = Omit<E, 'a'>;
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [
+    string,
+    number
+];

--- a/baselines/reference/ts3.6/src/test.d.ts
+++ b/baselines/reference/ts3.6/src/test.d.ts
@@ -19,3 +19,8 @@ export interface E {
     b: number;
 }
 export type F = Omit<E, 'a'>;
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [
+    string,
+    number
+];

--- a/baselines/reference/ts3.7/src/test.d.ts
+++ b/baselines/reference/ts3.7/src/test.d.ts
@@ -19,3 +19,8 @@ export interface E {
     b: number;
 }
 export type F = Omit<E, 'a'>;
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [
+    string,
+    number
+];

--- a/baselines/reference/ts3.8/src/test.d.ts
+++ b/baselines/reference/ts3.8/src/test.d.ts
@@ -19,3 +19,8 @@ export interface E {
     b: number;
 }
 export type F = Omit<E, 'a'>;
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [
+    string,
+    number
+];

--- a/baselines/reference/ts3.9/src/test.d.ts
+++ b/baselines/reference/ts3.9/src/test.d.ts
@@ -19,3 +19,8 @@ export interface E {
     b: number;
 }
 export type F = Omit<E, 'a'>;
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [
+    string,
+    number
+];

--- a/baselines/reference/ts4.0/src/test.d.ts
+++ b/baselines/reference/ts4.0/src/test.d.ts
@@ -19,3 +19,8 @@ export interface E {
     b: number;
 }
 export type F = Omit<E, 'a'>;
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [
+    string,
+    number
+];

--- a/index.test.js
+++ b/index.test.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const semver = require("semver");
 
 describe("main", () => {
-  const tsVersions = ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0"];
+  const tsVersions = ["3.3", "3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0"];
 
   if (fs.existsSync(`baselines/local`)) {
     sh.rm("-r", `baselines/local`);

--- a/test/src/test.d.ts
+++ b/test/src/test.d.ts
@@ -23,3 +23,6 @@ export interface E {
 }
 
 export type F = Omit<E, 'a'>;
+
+export declare let readonlyArr: readonly string[];
+export declare let readonlyTuple: readonly [string, number];


### PR DESCRIPTION
Related to https://github.com/sandersn/downlevel-dts/issues/27. 
Add some code for Compatibility of readonly array & readonly tuple before 3.4 .
It may be helpful.