### PR TITLE
<3.8 rather than <=3.5 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ downlevelled, nor are there any other plans to support Typescript 2.x.
 
 ```json
 "typesVersions": {
-  "<=3.5": { "*": ["ts3.4/*"] }
+  "<3.8": { "*": ["ts3.4/*"] }
 }
 ```
 


### PR DESCRIPTION
If I understand the rest of the readme correctly, the safe thing to do is for all versions of TypeScript <3.8 to load the old typings, as there are 3.5, 3.6 and 3.8 features that are downleveled.