### PR TITLE
Downlevel Omit when used as ExpressionWithTypeArguments

### DIFF
--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -27,3 +27,6 @@ export class G {
 export class H extends G {
     private "H.#private";
 }
+export interface I extends Pick<E, Exclude<keyof E, 'a'>> {
+    version: number;
+}

--- a/index.js
+++ b/index.js
@@ -124,29 +124,10 @@ function doTransform(checker, k) {
     } else if (ts.isImportClause(n) && n.isTypeOnly) {
       return ts.createImportClause(n.name, n.namedBindings);
     } else if (
-      ts.isExpressionWithTypeArguments(n) &&
-      ts.isIdentifier(n.expression) &&
-      n.expression.escapedText === "Omit"
+      (ts.isTypeReferenceNode(n) && ts.isIdentifier(n.typeName) && n.typeName.escapedText === "Omit") ||
+      (ts.isExpressionWithTypeArguments(n) && ts.isIdentifier(n.expression) && n.expression.escapedText === "Omit")
     ) {
-      const symbol = checker.getSymbolAtLocation(n.expression);
-      const typeArguments = n.typeArguments;
-
-      if (
-        symbol &&
-        symbol.declarations.length &&
-        symbol.declarations[0].getSourceFile().fileName.includes("node_modules/typescript/lib/lib") &&
-        typeArguments
-      ) {
-        return ts.createTypeReferenceNode(ts.createIdentifier("Pick"), [
-          typeArguments[0],
-          ts.createTypeReferenceNode(ts.createIdentifier("Exclude"), [
-            ts.createTypeOperatorNode(typeArguments[0]),
-            typeArguments[1]
-          ])
-        ]);
-      }
-    } else if (ts.isTypeReferenceNode(n) && ts.isIdentifier(n.typeName) && n.typeName.escapedText === "Omit") {
-      const symbol = checker.getSymbolAtLocation(n.typeName);
+      const symbol = checker.getSymbolAtLocation(ts.isTypeReferenceNode(n) ? n.typeName : n.expression);
       const typeArguments = n.typeArguments;
 
       if (

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -32,3 +32,7 @@ export class G {
 export class H extends G {
     #private
 }
+
+export interface I extends Omit<E, 'a'> {
+    version: number;
+}


### PR DESCRIPTION
This pull request is intended to fix #33 

The code is very similar to the one which down-levels Omit when used in a TypeReferenceNode. Should I refactor it into a function which can be used for both cases?