### PR TITLE
Update for 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ declare class C {
 }
 ```
 
+Note that not all features can be downlevelled. For example,
+Typescript 4.0 allows spreading multiple tuple type variables, at any
+position in a tuple. This is not allowed in previous versions, but has
+no obvious downlevel emit, so downlevel-dts doesn't attempt to do
+anything. Be sure to test the output of downlevel-dts with the
+appropriate version of Typescript.
+
 ## Features
 
 Here is the list of features that are downlevelled:
@@ -208,6 +215,25 @@ export { ns_1 as ns };
 #### Semantics
 
 The downlevel semantics should be exactly the same as the original.
+
+### `[named: number, tuple: string, ...members: boolean[]]` (4.0)
+
+Typescript 4.0 supports naming tuple members:
+
+```ts
+type T = [foo: number, bar: string];
+```
+
+becomes
+
+```ts
+type T = [/** foo */ number, /** bar */ string];
+```
+
+#### Semantics
+
+The downlevel semantics are exactly the same as the original, but
+the Typescript language service won't be able to show the member names.
 
 ## Target
 

--- a/README.md
+++ b/README.md
@@ -228,10 +228,10 @@ downlevelled, nor are there any other plans to support Typescript 2.x.
 
 ```json
 "typesVersions": {
-  "<3.8": { "*": ["ts3.4/*"] }
+  "<3.9": { "*": ["ts3.4/*"] }
 }
 ```
 
-4. `$ cp tsconfig.json ts3.4/tsconfig.json`
+4. `$ cp tsconfig.json ts3.9/tsconfig.json`
 
-These instructions are modified and simplified from the Definitely Typed.
+These instructions are modified and simplified from the Definitely Typed ones.

--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -43,3 +43,8 @@ declare function guardIsString(val: any): val is string;
 /** side-effects! */
 declare function assertIsString(val: any, msg?: string): void;
 declare function assert(val: any, msg?: string): void;
+type J = [
+    /*foo*/ string,
+    /*bar*/ number,
+    /*arr*/ ...boolean[]
+];

--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -8,18 +8,27 @@ export class C {
 // hi, this should still be there
 export namespace N {
     abstract class D {
+        /*
+        * @readonly
+        * @memberof BlobLeaseClient
+        * @type {number}
+        
+        preserve this too */
         p: number;
         readonly q: any;
         abstract r: boolean;
     }
 }
+/** is this a single-line comment? */
 import { C as CD } from "./src/test";
 import * as rex_1 from "./src/test";
+//another comment
 export { rex_1 as rex } from "./src/test";
 export interface E {
     a: number;
     b: number;
 }
+/// is this a single-line comment?
 export type F = Pick<E, Exclude<keyof E, 'a'>>;
 export class G {
     private "G.#private";
@@ -31,5 +40,6 @@ export interface I extends Pick<E, Exclude<keyof E, 'a'>> {
     version: number;
 }
 declare function guardIsString(val: any): val is string;
+/** side-effects! */
 declare function assertIsString(val: any, msg?: string): void;
 declare function assert(val: any, msg?: string): void;

--- a/index.js
+++ b/index.js
@@ -202,9 +202,10 @@ function getMatchingAccessor(n, getset) {
  */
 function copyComment(originals, rewrite) {
   const file = originals[0].getSourceFile().getFullText();
-  const ranges = flatMap(originals, o =>
-    /** @type {ts.CommentRange[]} */ (ts.getLeadingCommentRanges(file, o.getFullStart()))
-  ).filter(x => x !== undefined);
+  const ranges = flatMap(originals, o => {
+    const comments = ts.getLeadingCommentRanges(file, o.getFullStart());
+    return comments ? comments : [];
+  });
   if (!ranges.length) return rewrite;
 
   let kind = ts.SyntaxKind.SingleLineCommentTrivia;

--- a/index.js
+++ b/index.js
@@ -168,6 +168,14 @@ function doTransform(checker, k) {
           ])
         ]);
       }
+    } else if (n.kind === ts.SyntaxKind.NamedTupleMember) {
+      const member = /** @type {import("typescript").NamedTupleMember} */ (n);
+      return ts.addSyntheticLeadingComment(
+        member.dotDotDotToken ? ts.createRestTypeNode(member.type) : member.type,
+        ts.SyntaxKind.MultiLineCommentTrivia,
+        ts.unescapeLeadingUnderscores(member.name.escapedText),
+        /*hasTrailingNewline*/ false
+      );
     }
     return ts.visitEachChild(n, transform, k);
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -5775,9 +5775,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.0-dev.20200111",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200111.tgz",
-      "integrity": "sha512-9LNK1LhRc7V5WA32tI9i2MDOYWz9DaTNb6TtWcR50trm0C2oA/FyuT/mxSbKZwrxh5becNhaehiR/sgDO64v0g=="
+      "version": "4.1.0-dev.20200804",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20200804.tgz",
+      "integrity": "sha512-jbvJc9pFunwJz7u0JMjorH8AI+Me+gBVZUSKDPTBFWP4rVvQHCg1pJBQ9znGsOFzsxK+vexJKOXXbSWinw8ZQg=="
     },
     "uglify-js": {
       "version": "3.7.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "shelljs": "^0.8.3",
-    "typescript": "^3.8.0-dev.20200111"
+    "typescript": "^4.1.0-dev.20200804"
   },
   "devDependencies": {
     "@types/node": "^13.1.6",

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -48,3 +48,5 @@ declare function guardIsString(val: any): val is string;
 /** side-effects! */
 declare function assertIsString(val: any, msg?: string): asserts val is string;
 declare function assert(val: any, msg?: string): asserts val;
+
+type J = [foo: string, bar: number, ...arr:boolean[]]

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -9,7 +9,13 @@ export class C {
 // hi, this should still be there
 export namespace N {
   abstract class D {
+    /**
+     * @readonly
+     * @memberof BlobLeaseClient
+     * @type {number}
+     */
     get p(): number;
+    /** preserve this too */
     set p(value: number);
     get q();
     abstract set r(value: boolean);
@@ -24,7 +30,7 @@ export interface E {
   b: number;
 }
 
-export type F = Omit<E, 'a'>;
+export type F = Omit<E, 'a'>
 
 export class G {
     #private

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -21,8 +21,10 @@ export namespace N {
     abstract set r(value: boolean);
   }
 }
+/** is this a single-line comment? */
 import type { C as CD } from "./src/test";
 
+// another comment
 export * as rex from "./src/test";
 
 export interface E {
@@ -30,6 +32,7 @@ export interface E {
   b: number;
 }
 
+/// is this a single-line comment?
 export type F = Omit<E, 'a'>
 
 export class G {
@@ -42,5 +45,6 @@ export interface I extends Omit<E, 'a'> {
     version: number;
 }
 declare function guardIsString(val: any): val is string;
+/** side-effects! */
 declare function assertIsString(val: any, msg?: string): asserts val is string;
 declare function assert(val: any, msg?: string): asserts val;


### PR DESCRIPTION
1. Update README.
2. Remove tuple member names.
3. Preserve comments (but don't preserve indentation).

Fixes #19 
Fixes microsoft/TypeScript#39099