### PR TITLE
Test `export * as default from 'foo'`

### DIFF
--- a/baselines/ts3.4/test.d.ts
+++ b/baselines/ts3.4/test.d.ts
@@ -48,3 +48,5 @@ type J = [
     /*bar*/ number,
     /*arr*/ ...boolean[]
 ];
+import * as default_1 from "./src/test";
+export { default_1 as default };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "downlevel-dts",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5775,9 +5775,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.0-dev.20200804",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20200804.tgz",
-      "integrity": "sha512-jbvJc9pFunwJz7u0JMjorH8AI+Me+gBVZUSKDPTBFWP4rVvQHCg1pJBQ9znGsOFzsxK+vexJKOXXbSWinw8ZQg=="
+      "version": "4.1.0-dev.20201026",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20201026.tgz",
+      "integrity": "sha512-eeu0PiTyVU+obXKWYUAOVkPjKFzQOdLYGbGvd5TbcQ/CH7c5N7Q3VBuVdO8/rUhau8vw7Mc3EWzCnw7WUG0Img=="
     },
     "uglify-js": {
       "version": "3.7.4",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "dependencies": {
     "shelljs": "^0.8.3",
-    "typescript": "^4.1.0-dev.20200804"
+    "typescript": "^4.1.0-dev.20201026"
   },
   "devDependencies": {
     "@types/node": "^13.1.6",

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -1,5 +1,6 @@
-/// <reference types="node" />
 /// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+
 export class C {
   protected get p(): number;
   protected set p(value: number);
@@ -50,3 +51,5 @@ declare function assertIsString(val: any, msg?: string): asserts val is string;
 declare function assert(val: any, msg?: string): asserts val;
 
 type J = [foo: string, bar: number, ...arr:boolean[]]
+
+export * as default from "./src/test";


### PR DESCRIPTION
This already works with TS 4.1, so I

1. Added a test.
2. Updated to a newer version of TS.

Also includes a bug fix for order of emit of triple-slash comments.

Fixes #45