### PR TITLE
Downlevel type alias function assertions

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "npm test",
+      "type": "node",
+      "protocol": "inspector",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["test"],
+      "stopOnEntry": false,
+      "env": {},
+      "sourceMaps": true
+    }
+  ]
+}

--- a/baselines/reference/ts3.4/test.d.ts
+++ b/baselines/reference/ts3.4/test.d.ts
@@ -50,3 +50,9 @@ type J = [
 ];
 import * as default_1 from "./src/test";
 export { default_1 as default };
+export declare type Asserts<T> = (val: unknown) => void;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => void;
+    };
+};

--- a/baselines/reference/ts3.5/test.d.ts
+++ b/baselines/reference/ts3.5/test.d.ts
@@ -50,3 +50,9 @@ type J = [
 ];
 import * as default_1 from "./src/test";
 export { default_1 as default };
+export declare type Asserts<T> = (val: unknown) => void;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => void;
+    };
+};

--- a/baselines/reference/ts3.6/test.d.ts
+++ b/baselines/reference/ts3.6/test.d.ts
@@ -52,3 +52,9 @@ type J = [
 ];
 import * as default_1 from "./src/test";
 export { default_1 as default };
+export declare type Asserts<T> = (val: unknown) => void;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => void;
+    };
+};

--- a/baselines/reference/ts3.7/test.d.ts
+++ b/baselines/reference/ts3.7/test.d.ts
@@ -52,3 +52,9 @@ type J = [
 ];
 import * as default_1 from "./src/test";
 export { default_1 as default };
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};

--- a/baselines/reference/ts3.8/test.d.ts
+++ b/baselines/reference/ts3.8/test.d.ts
@@ -50,3 +50,9 @@ type J = [
     /*arr*/ ...boolean[]
 ];
 export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};

--- a/baselines/reference/ts3.9/test.d.ts
+++ b/baselines/reference/ts3.9/test.d.ts
@@ -50,3 +50,9 @@ type J = [
     /*arr*/ ...boolean[]
 ];
 export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};

--- a/baselines/reference/ts4.0/test.d.ts
+++ b/baselines/reference/ts4.0/test.d.ts
@@ -50,3 +50,9 @@ type J = [
     ...arr: boolean[]
 ];
 export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};

--- a/index.js
+++ b/index.js
@@ -61,23 +61,23 @@ function doTransform(checker, targetVersion, k) {
    * @return {import("typescript").VisitResult<Node>}
    */
   const transform = function(n) {
-    if (
-      semver.lt(targetVersion, "3.7.0") &&
-      ts.isFunctionDeclaration(n) &&
-      n.type &&
-      ts.isTypePredicateNode(n.type) &&
-      n.type.assertsModifier
-    ) {
-      return ts.createFunctionDeclaration(
-        n.decorators,
-        n.modifiers,
-        n.asteriskToken,
-        n.name,
-        n.typeParameters,
-        n.parameters,
-        ts.createTypeReferenceNode("void", undefined),
-        n.body
-      );
+    if (semver.lt(targetVersion, "3.7.0")) {
+      if (ts.isFunctionTypeNode(n) && n.type && ts.isTypePredicateNode(n.type) && n.type.assertsModifier) {
+        return ts.createFunctionTypeNode(n.typeParameters, n.parameters, ts.createTypeReferenceNode("void", undefined));
+      }
+
+      if (ts.isFunctionDeclaration(n) && n.type && ts.isTypePredicateNode(n.type) && n.type.assertsModifier) {
+        return ts.createFunctionDeclaration(
+          n.decorators,
+          n.modifiers,
+          n.asteriskToken,
+          n.name,
+          n.typeParameters,
+          n.parameters,
+          ts.createTypeReferenceNode("void", undefined),
+          n.body
+        );
+      }
     }
 
     if (semver.lt(targetVersion, "3.6.0") && ts.isGetAccessor(n)) {

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -53,3 +53,11 @@ declare function assert(val: any, msg?: string): asserts val;
 type J = [foo: string, bar: number, ...arr:boolean[]]
 
 export * as default from "./src/test";
+
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};


### PR DESCRIPTION
Properly downlevels `type Foo<T> = (val: unknown) => asserts val is T` to `type Foo<T> = (val: unknown) => void`

I also added a debug file for VSCode devs. It makes it a little easier to get started debugging the tests. Happy to remove that if you don't want to include it in the project!

I discovered this issue while writing some type assertions today (see relevant changes [here](https://github.com/microsoft/botbuilder-js/pull/3066/files#diff-9b546a3a8b1030340c9c20edc96fc3f7bb3b3dd69c942d7b8b393f16a5727d3b)). The files produced by `downlevel-dts` failed to compile in older Typescript versions. This should fix the two cases I ran into.