### PR TITLE
Update usage to cover TS 3.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ downlevelled, nor are there any other plans to support Typescript 2.x.
 
 ```json
 "typesVersions": {
-  "<=3.9": { "*": ["ts3.4/*"] }
+  "<4.0": { "*": ["ts3.4/*"] }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ downlevelled, nor are there any other plans to support Typescript 2.x.
 
 ```json
 "typesVersions": {
-  "<3.9": { "*": ["ts3.4/*"] }
+  "<=3.9": { "*": ["ts3.4/*"] }
 }
 ```
 


### PR DESCRIPTION
This is in order to get downlevel for the covered TS 4.0 features as well (named tuple memberes).