### PR TITLE
Downlevel IteratorResult for TS < v3.6

### DIFF
--- a/baselines/reference/ts3.4/test.d.ts
+++ b/baselines/reference/ts3.4/test.d.ts
@@ -56,3 +56,4 @@ export declare const foo: {
         baz: <T>(val: unknown) => void;
     };
 };
+export type IR = IteratorResult<number>;

--- a/baselines/reference/ts3.5/test.d.ts
+++ b/baselines/reference/ts3.5/test.d.ts
@@ -56,3 +56,4 @@ export declare const foo: {
         baz: <T>(val: unknown) => void;
     };
 };
+export type IR = IteratorResult<number>;

--- a/baselines/reference/ts3.6/test.d.ts
+++ b/baselines/reference/ts3.6/test.d.ts
@@ -58,3 +58,4 @@ export declare const foo: {
         baz: <T>(val: unknown) => void;
     };
 };
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts3.7/test.d.ts
+++ b/baselines/reference/ts3.7/test.d.ts
@@ -58,3 +58,4 @@ export declare const foo: {
         baz: <T>(val: unknown) => asserts val is T;
     };
 };
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts3.8/test.d.ts
+++ b/baselines/reference/ts3.8/test.d.ts
@@ -56,3 +56,4 @@ export declare const foo: {
         baz: <T>(val: unknown) => asserts val is T;
     };
 };
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts3.9/test.d.ts
+++ b/baselines/reference/ts3.9/test.d.ts
@@ -56,3 +56,4 @@ export declare const foo: {
         baz: <T>(val: unknown) => asserts val is T;
     };
 };
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts4.0/test.d.ts
+++ b/baselines/reference/ts4.0/test.d.ts
@@ -56,3 +56,4 @@ export declare const foo: {
         baz: <T>(val: unknown) => asserts val is T;
     };
 };
+export type IR = IteratorResult<number, string>;

--- a/index.js
+++ b/index.js
@@ -118,17 +118,10 @@ function doTransform(checker, targetVersion, k) {
           )
         );
       }
-    } else if (
-      semver.lt(targetVersion, "3.6.0") &&
-      ((ts.isTypeReferenceNode(n) && ts.isIdentifier(n.typeName) && n.typeName.escapedText === "IteratorResult") ||
-        (ts.isExpressionWithTypeArguments(n) &&
-          ts.isIdentifier(n.expression) &&
-          n.expression.escapedText === "IteratorResult"))
-    ) {
+    } else if (semver.lt(targetVersion, "3.6.0") && isTypeReference(n, "IteratorResult")) {
       const symbol = checker.getSymbolAtLocation(ts.isTypeReferenceNode(n) ? n.typeName : n.expression);
       const typeArguments = n.typeArguments;
       if (
-        semver.lt(targetVersion, "3.6.0") &&
         symbol &&
         symbol.declarations.length &&
         symbol.declarations[0].getSourceFile().fileName.includes("node_modules/typescript/lib/lib") &&
@@ -185,10 +178,7 @@ function doTransform(checker, targetVersion, k) {
       return ts.createExportDeclaration(n.decorators, n.modifiers, n.exportClause, n.moduleSpecifier);
     } else if (semver.lt(targetVersion, "3.8.0") && ts.isImportClause(n) && n.isTypeOnly) {
       return ts.createImportClause(n.name, n.namedBindings);
-    } else if (
-      (ts.isTypeReferenceNode(n) && ts.isIdentifier(n.typeName) && n.typeName.escapedText === "Omit") ||
-      (ts.isExpressionWithTypeArguments(n) && ts.isIdentifier(n.expression) && n.expression.escapedText === "Omit")
-    ) {
+    } else if (isTypeReference(n, "Omit")) {
       const symbol = checker.getSymbolAtLocation(ts.isTypeReferenceNode(n) ? n.typeName : n.expression);
       const typeArguments = n.typeArguments;
 
@@ -295,4 +285,19 @@ function flatMap(l, f) {
     acc.push(...ys);
   }
   return acc;
+}
+
+/**
+ * Checks whether a node is a type reference with typeName as a name
+ * @param {ts.Node} node AST node
+ * @param {string} typeName name of the type
+ * @returns true if the node is a type reference with typeName as a name
+ */
+function isTypeReference(node, typeName) {
+  return (
+    (ts.isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) && node.typeName.escapedText === typeName) ||
+    (ts.isExpressionWithTypeArguments(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.escapedText === typeName)
+  );
 }

--- a/index.js
+++ b/index.js
@@ -119,6 +119,24 @@ function doTransform(checker, targetVersion, k) {
         );
       }
     } else if (
+      semver.lt(targetVersion, "3.6.0") &&
+      ((ts.isTypeReferenceNode(n) && ts.isIdentifier(n.typeName) && n.typeName.escapedText === "IteratorResult") ||
+        (ts.isExpressionWithTypeArguments(n) &&
+          ts.isIdentifier(n.expression) &&
+          n.expression.escapedText === "IteratorResult"))
+    ) {
+      const symbol = checker.getSymbolAtLocation(ts.isTypeReferenceNode(n) ? n.typeName : n.expression);
+      const typeArguments = n.typeArguments;
+      if (
+        semver.lt(targetVersion, "3.6.0") &&
+        symbol &&
+        symbol.declarations.length &&
+        symbol.declarations[0].getSourceFile().fileName.includes("node_modules/typescript/lib/lib") &&
+        typeArguments
+      ) {
+        return ts.createTypeReferenceNode(ts.createIdentifier("IteratorResult"), [typeArguments[0]]);
+      }
+    } else if (
       semver.lt(targetVersion, "3.8.0") &&
       ts.isPropertyDeclaration(n) &&
       ts.isPrivateIdentifier(n.name) &&

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "downlevel-dts",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -882,6 +882,16 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1634,6 +1644,13 @@
         "bser": "2.1.1"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
+    },
     "fill-range": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1702,6 +1719,17 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "fsevents": {
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+      "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.12.1"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -2512,6 +2540,7 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -3168,6 +3197,13 @@
         "arrify": "^2.0.1",
         "minimatch": "^3.0.4"
       }
+    },
+    "nan": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
+      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "downlevel-dts",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Convert d.ts to be compatible with older typescript compilers",
   "homepage": "https://github.com/sandersn/downlevel-dts",
   "main": "index.js",

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -61,3 +61,5 @@ export declare const foo: {
         baz: <T>(val: unknown) => asserts val is T;
     };
 };
+
+export type IR = IteratorResult<number, string>;


### PR DESCRIPTION
Fixes https://github.com/sandersn/downlevel-dts/issues/40

[`IteratorResult` definition changed in TS v3.6 to have another type argument for return expressions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-6.html#stricter-generators). This PR adds downleveling for this type by removing that second type variable for TS v < 3.6.