### PR TITLE
Downlevel type modifiers on import/export names for TS <4.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,56 @@ import { C } from "x";
 var c = new C();
 ```
 
+### `type` modifiers on import names (4.5)
+
+The downlevel emit depends on the TypeScript target version and whether type and
+value imports are mixed.
+
+An import declaration with only import names that have `type` modifiers
+
+```ts
+import { type A, type B } from "x";
+```
+
+becomes:
+
+```ts
+// TS 3.8+
+import type { A, B } from "x";
+
+// TS 3.7 or less
+import { A, B } from "x";
+```
+
+A mixed import declaration
+
+```ts
+import { A, type B } from "x";
+```
+
+becomes:
+
+```ts
+// TS 3.8+
+import type { B } from "x";
+import { A } from "x";
+
+// TS 3.7 or less
+import { A, B } from "x";
+```
+
+#### Semantics
+
+When an import declaration has only import names with `type` modifiers, it is
+emitted as a type-only import declaration for TS 3.8+ and as a value import
+declaration for TS 3.7 or less. The latter will be less strict (see
+[type-only import/export](#type-only-importexport-38)).
+
+When type and value imports are mixed, two import declarations are emitted for
+TS 3.8+, one for type-only imports and another one for value imports. For TS 3.7
+or less, one value import declaration is emitted which will be less strict (see
+[type-only import/export](#type-only-importexport-38)).
+
 ### `#private` (3.8)
 
 TypeScript 3.8 supports the new ECMAScript-standard #private properties in

--- a/README.md
+++ b/README.md
@@ -135,15 +135,17 @@ import { C } from "x";
 var c = new C();
 ```
 
-### `type` modifiers on import names (4.5)
+### `type` modifiers on import/export names (4.5)
 
 The downlevel emit depends on the TypeScript target version and whether type and
-value imports are mixed.
+value imports/exports are mixed.
 
-An import declaration with only import names that have `type` modifiers
+An import/export declaration with only import/export names that have `type`
+modifiers
 
 ```ts
 import { type A, type B } from "x";
+export { type A, type B };
 ```
 
 becomes:
@@ -151,15 +153,18 @@ becomes:
 ```ts
 // TS 3.8+
 import type { A, B } from "x";
+export type { A, B };
 
 // TS 3.7 or less
 import { A, B } from "x";
+export { A, B };
 ```
 
-A mixed import declaration
+A mixed import/export declaration
 
 ```ts
 import { A, type B } from "x";
+export { A, type B };
 ```
 
 becomes:
@@ -168,21 +173,25 @@ becomes:
 // TS 3.8+
 import type { B } from "x";
 import { A } from "x";
+export type { B };
+export { A };
 
 // TS 3.7 or less
 import { A, B } from "x";
+export { A, B };
 ```
 
 #### Semantics
 
-When an import declaration has only import names with `type` modifiers, it is
-emitted as a type-only import declaration for TS 3.8+ and as a value import
-declaration for TS 3.7 or less. The latter will be less strict (see
-[type-only import/export](#type-only-importexport-38)).
+When an import/export declaration has only import/export names with `type`
+modifiers, it is emitted as a type-only import/export declaration for TS 3.8+
+and as a value import/export declaration for TS 3.7 or less. The latter will be
+less strict (see [type-only import/export](#type-only-importexport-38)).
 
-When type and value imports are mixed, two import declarations are emitted for
-TS 3.8+, one for type-only imports and another one for value imports. For TS 3.7
-or less, one value import declaration is emitted which will be less strict (see
+When type and value imports/exports are mixed, two import/export declarations
+are emitted for TS 3.8+, one for type-only imports/exports and another one for
+value imports/exports. For TS 3.7 or less, one value import/export declaration
+is emitted which will be less strict (see
 [type-only import/export](#type-only-importexport-38)).
 
 ### `#private` (3.8)

--- a/baselines/reference/ts3.4/test.d.ts
+++ b/baselines/reference/ts3.4/test.d.ts
@@ -25,6 +25,14 @@ import { C as CD } from "./src/test";
 import { C as CD2, C as CD3 } from "./src/test";
 /*this too */
 import { C as CD4, C as CD5 } from "./src/test";
+/*preserve it */
+export { CD2, CD3 };
+/*this too */
+export { CD4, CD5 };
+/*preserve it */
+export { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export { C as CD8, C as CD9 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.4/test.d.ts
+++ b/baselines/reference/ts3.4/test.d.ts
@@ -21,6 +21,10 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import { C as CD } from "./src/test";
+/*preserve it */
+import { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import { C as CD4, C as CD5 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.5/test.d.ts
+++ b/baselines/reference/ts3.5/test.d.ts
@@ -25,6 +25,14 @@ import { C as CD } from "./src/test";
 import { C as CD2, C as CD3 } from "./src/test";
 /*this too */
 import { C as CD4, C as CD5 } from "./src/test";
+/*preserve it */
+export { CD2, CD3 };
+/*this too */
+export { CD4, CD5 };
+/*preserve it */
+export { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export { C as CD8, C as CD9 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.5/test.d.ts
+++ b/baselines/reference/ts3.5/test.d.ts
@@ -21,6 +21,10 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import { C as CD } from "./src/test";
+/*preserve it */
+import { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import { C as CD4, C as CD5 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.6/test.d.ts
+++ b/baselines/reference/ts3.6/test.d.ts
@@ -23,6 +23,10 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import { C as CD } from "./src/test";
+/*preserve it */
+import { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import { C as CD4, C as CD5 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.6/test.d.ts
+++ b/baselines/reference/ts3.6/test.d.ts
@@ -27,6 +27,14 @@ import { C as CD } from "./src/test";
 import { C as CD2, C as CD3 } from "./src/test";
 /*this too */
 import { C as CD4, C as CD5 } from "./src/test";
+/*preserve it */
+export { CD2, CD3 };
+/*this too */
+export { CD4, CD5 };
+/*preserve it */
+export { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export { C as CD8, C as CD9 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.7/test.d.ts
+++ b/baselines/reference/ts3.7/test.d.ts
@@ -23,6 +23,10 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import { C as CD } from "./src/test";
+/*preserve it */
+import { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import { C as CD4, C as CD5 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.7/test.d.ts
+++ b/baselines/reference/ts3.7/test.d.ts
@@ -27,6 +27,14 @@ import { C as CD } from "./src/test";
 import { C as CD2, C as CD3 } from "./src/test";
 /*this too */
 import { C as CD4, C as CD5 } from "./src/test";
+/*preserve it */
+export { CD2, CD3 };
+/*this too */
+export { CD4, CD5 };
+/*preserve it */
+export { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export { C as CD8, C as CD9 } from "./src/test";
 import * as rex_1 from "./src/test";
 //another comment
 export { rex_1 as rex };

--- a/baselines/reference/ts3.8/test.d.ts
+++ b/baselines/reference/ts3.8/test.d.ts
@@ -23,6 +23,11 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import type { C as CD } from "./src/test";
+/*preserve it */
+import type { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import type { C as CD5 } from "./src/test";
+import { C as CD4 } from "./src/test";
 // another comment
 export * as rex from "./src/test";
 export interface E {

--- a/baselines/reference/ts3.8/test.d.ts
+++ b/baselines/reference/ts3.8/test.d.ts
@@ -28,6 +28,16 @@ import type { C as CD2, C as CD3 } from "./src/test";
 /*this too */
 import type { C as CD5 } from "./src/test";
 import { C as CD4 } from "./src/test";
+/*preserve it */
+export type { CD2, CD3 };
+/*this too */
+export type { CD5 };
+export { CD4 };
+/*preserve it */
+export type { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export type { C as CD9 } from "./src/test";
+export { C as CD8 } from "./src/test";
 // another comment
 export * as rex from "./src/test";
 export interface E {

--- a/baselines/reference/ts3.9/test.d.ts
+++ b/baselines/reference/ts3.9/test.d.ts
@@ -23,6 +23,11 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import type { C as CD } from "./src/test";
+/*preserve it */
+import type { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import type { C as CD5 } from "./src/test";
+import { C as CD4 } from "./src/test";
 // another comment
 export * as rex from "./src/test";
 export interface E {

--- a/baselines/reference/ts3.9/test.d.ts
+++ b/baselines/reference/ts3.9/test.d.ts
@@ -28,6 +28,16 @@ import type { C as CD2, C as CD3 } from "./src/test";
 /*this too */
 import type { C as CD5 } from "./src/test";
 import { C as CD4 } from "./src/test";
+/*preserve it */
+export type { CD2, CD3 };
+/*this too */
+export type { CD5 };
+export { CD4 };
+/*preserve it */
+export type { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export type { C as CD9 } from "./src/test";
+export { C as CD8 } from "./src/test";
 // another comment
 export * as rex from "./src/test";
 export interface E {

--- a/baselines/reference/ts4.0/test.d.ts
+++ b/baselines/reference/ts4.0/test.d.ts
@@ -23,6 +23,11 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import type { C as CD } from "./src/test";
+/*preserve it */
+import type { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import type { C as CD5 } from "./src/test";
+import { C as CD4 } from "./src/test";
 // another comment
 export * as rex from "./src/test";
 export interface E {

--- a/baselines/reference/ts4.0/test.d.ts
+++ b/baselines/reference/ts4.0/test.d.ts
@@ -28,6 +28,16 @@ import type { C as CD2, C as CD3 } from "./src/test";
 /*this too */
 import type { C as CD5 } from "./src/test";
 import { C as CD4 } from "./src/test";
+/*preserve it */
+export type { CD2, CD3 };
+/*this too */
+export type { CD5 };
+export { CD4 };
+/*preserve it */
+export type { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export type { C as CD9 } from "./src/test";
+export { C as CD8 } from "./src/test";
 // another comment
 export * as rex from "./src/test";
 export interface E {

--- a/index.js
+++ b/index.js
@@ -180,6 +180,7 @@ function doTransform(checker, targetVersion, k) {
       n.importClause &&
       !n.importClause.isTypeOnly &&
       n.importClause.namedBindings &&
+      ts.isNamedImports(n.importClause.namedBindings) &&
       n.importClause.namedBindings.elements.some(e => e.isTypeOnly)
     ) {
       const elements = n.importClause.namedBindings.elements;
@@ -245,7 +246,7 @@ function doTransform(checker, targetVersion, k) {
             n.decorators,
             n.modifiers,
             ts.createImportClause(
-              n.name,
+              n.importClause.name,
               ts.createNamedImports(valueElements.map(e => ts.createImportSpecifier(false, e.propertyName, e.name)))
             ),
             n.moduleSpecifier

--- a/index.js
+++ b/index.js
@@ -165,7 +165,7 @@ function doTransform(checker, targetVersion, k) {
           ts.createExportDeclaration(
             undefined,
             undefined,
-            ts.createNamedExports([ts.createExportSpecifier(tempName, n.exportClause.name)])
+            ts.createNamedExports([ts.createExportSpecifier(false, tempName, n.exportClause.name)])
           )
         )
       ];
@@ -173,6 +173,85 @@ function doTransform(checker, targetVersion, k) {
       return ts.createExportDeclaration(n.decorators, n.modifiers, n.exportClause, n.moduleSpecifier);
     } else if (semver.lt(targetVersion, "3.8.0") && ts.isImportClause(n) && n.isTypeOnly) {
       return ts.createImportClause(n.name, n.namedBindings);
+    } else if (
+      semver.lt(targetVersion, "4.5.0") &&
+      ts.isImportDeclaration(n) &&
+      !n.modifiers &&
+      n.importClause &&
+      !n.importClause.isTypeOnly &&
+      n.importClause.namedBindings &&
+      n.importClause.namedBindings.elements.some(e => e.isTypeOnly)
+    ) {
+      const elements = n.importClause.namedBindings.elements;
+
+      if (semver.lt(targetVersion, "3.8.0")) {
+        // import { A, type B } from 'x'
+        // =>
+        // import { A, B } from 'x'
+        return copyComment(
+          [n],
+          ts.createImportDeclaration(
+            n.decorators,
+            n.modifiers,
+            ts.createImportClause(
+              n.importClause.name,
+              ts.createNamedImports(elements.map(e => ts.createImportSpecifier(false, e.propertyName, e.name)))
+            ),
+            n.moduleSpecifier
+          )
+        );
+      }
+
+      const typeElements = [];
+      const valueElements = [];
+      for (const e of elements) {
+        if (e.isTypeOnly) {
+          typeElements.push(e);
+        } else {
+          valueElements.push(e);
+        }
+      }
+
+      // import { type A, type B, ... } from 'x'
+      // =>
+      // import type { A, B } from 'x'
+      const typeOnlyImportDeclaration = copyComment(
+        [n],
+        ts.createImportDeclaration(
+          n.decorators,
+          n.modifiers,
+          ts.createImportClause(
+            n.importClause.name,
+            ts.createNamedImports(typeElements.map(e => ts.createImportSpecifier(false, e.propertyName, e.name))),
+            true
+          ),
+          n.moduleSpecifier
+        )
+      );
+
+      if (valueElements.length === 0) {
+        // import { type A, type B } from 'x'
+        // =>
+        // import type { A, B } from 'x'
+        return typeOnlyImportDeclaration;
+      } else {
+        // import { A, type B } from 'x'
+        // =>
+        // import type { B } from 'x'
+        // import { A } from 'x'
+        return [
+          typeOnlyImportDeclaration,
+          ts.createImportDeclaration(
+            n.decorators,
+            n.modifiers,
+            ts.createImportClause(
+              n.name,
+              ts.createNamedImports(valueElements.map(e => ts.createImportSpecifier(false, e.propertyName, e.name)))
+            ),
+            n.moduleSpecifier
+          )
+        ];
+      }
     } else if (isTypeReference(n, "Omit")) {
       const symbol = checker.getSymbolAtLocation(ts.isTypeReferenceNode(n) ? n.typeName : n.expression);
       const typeArguments = n.typeArguments;
@@ -280,7 +359,7 @@ function flatMap(l, f) {
  * Checks whether a node is a type reference with typeName as a name
  * @param {ts.Node} node AST node
  * @param {string} typeName name of the type
- * @returns true if the node is a type reference with typeName as a name
+ * @returns {node is ts.TypeReferenceNode | ts.ExpressionWithTypeArguments} true if the node is a type reference with typeName as a name
  */
 function isTypeReference(node, typeName) {
   return (
@@ -299,6 +378,7 @@ function isTypeReference(node, typeName) {
 function isStdLibSymbol(symbol) {
   return (
     symbol &&
+    symbol.declarations &&
     symbol.declarations.length &&
     symbol.declarations[0].getSourceFile().fileName.includes("node_modules/typescript/lib/lib")
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -4623,9 +4623,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.0-dev.20201026",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.0-dev.20201026.tgz",
-      "integrity": "sha512-eeu0PiTyVU+obXKWYUAOVkPjKFzQOdLYGbGvd5TbcQ/CH7c5N7Q3VBuVdO8/rUhau8vw7Mc3EWzCnw7WUG0Img=="
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.5.tgz",
+      "integrity": "sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA=="
     },
     "uglify-js": {
       "version": "3.7.4",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
   "author": "Nathan Shively-Sanders",
   "license": "MIT",
   "dependencies": {
-    "shelljs": "^0.8.3",
     "semver": "^7.3.2",
-    "typescript": "^4.1.0-dev.20201026"
+    "shelljs": "^0.8.3",
+    "typescript": "^4.5.5"
   },
   "devDependencies": {
     "@types/node": "^13.1.6",

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -28,6 +28,14 @@ import type { C as CD } from "./src/test";
 import { type C as CD2, type C as CD3 } from "./src/test";
 /** this too */
 import { C as CD4, type C as CD5 } from "./src/test";
+/** preserve it */
+export { type CD2, type CD3 };
+/** this too */
+export { CD4, type CD5 };
+/** preserve it */
+export { type C as CD6, type C as CD7 } from "./src/test";
+/** this too */
+export { C as CD8, type C as CD9 } from "./src/test";
 
 // another comment
 export * as rex from "./src/test";

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -24,6 +24,10 @@ export namespace N {
 }
 /** is this a single-line comment? */
 import type { C as CD } from "./src/test";
+/** preserve it */
+import { type C as CD2, type C as CD3 } from "./src/test";
+/** this too */
+import { C as CD4, type C as CD5 } from "./src/test";
 
 // another comment
 export * as rex from "./src/test";


### PR DESCRIPTION
This PR adds support for downleveling `type` modifiers on import names introduced in TS 4.5.

Please feel free to request any changes, it's my first contribution to this project and first time using the TS API. One remark: The `copyComment` helper function seems to have a bug, it does not correctly preserve comments (see the test files).

Closes #66.