### PR TITLE
Add tests for TS 4.1 to 4.6

### DIFF
--- a/baselines/reference/ts4.1/src/test.d.ts
+++ b/baselines/reference/ts4.1/src/test.d.ts
@@ -1,0 +1,21 @@
+export class C {
+    get p(): number;
+    set p(value: number);
+    get q(): string;
+    set r(value: boolean);
+}
+export namespace N {
+    class D {
+        get p(): number;
+        set p(value: number);
+        get q(): string;
+        set r(value: boolean);
+    }
+}
+export type { C as DetectiveComics };
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Omit<E, 'a'>;

--- a/baselines/reference/ts4.1/test.d.ts
+++ b/baselines/reference/ts4.1/test.d.ts
@@ -1,0 +1,74 @@
+/// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+export class C {
+    protected get p(): number;
+    protected set p(value: number);
+    public get q(): string;
+    private set r(value: boolean);
+}
+// hi, this should still be there
+export namespace N {
+    abstract class D {
+        /**
+         * @readonly
+         * @memberof BlobLeaseClient
+         * @type {number}
+         */
+        get p(): number;
+        /** preserve this too */
+        set p(value: number);
+        get q();
+        abstract set r(value: boolean);
+    }
+}
+/** is this a single-line comment? */
+import type { C as CD } from "./src/test";
+/*preserve it */
+import type { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import type { C as CD5 } from "./src/test";
+import { C as CD4 } from "./src/test";
+/*preserve it */
+export type { CD2, CD3 };
+/*this too */
+export type { CD5 };
+export { CD4 };
+/*preserve it */
+export type { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export type { C as CD9 } from "./src/test";
+export { C as CD8 } from "./src/test";
+// another comment
+export * as rex from "./src/test";
+export interface E {
+    a: number;
+    b: number;
+}
+/// is this a single-line comment?
+export type F = Omit<E, 'a'>;
+export class G {
+    #private;
+}
+export class H extends G {
+    #private;
+}
+export interface I extends Omit<E, 'a'> {
+    version: number;
+}
+declare function guardIsString(val: any): val is string;
+/** side-effects! */
+declare function assertIsString(val: any, msg?: string): asserts val is string;
+declare function assert(val: any, msg?: string): asserts val;
+type J = [
+    foo: string,
+    bar: number,
+    ...arr: boolean[]
+];
+export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts4.2/src/test.d.ts
+++ b/baselines/reference/ts4.2/src/test.d.ts
@@ -1,0 +1,21 @@
+export class C {
+    get p(): number;
+    set p(value: number);
+    get q(): string;
+    set r(value: boolean);
+}
+export namespace N {
+    class D {
+        get p(): number;
+        set p(value: number);
+        get q(): string;
+        set r(value: boolean);
+    }
+}
+export type { C as DetectiveComics };
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Omit<E, 'a'>;

--- a/baselines/reference/ts4.2/test.d.ts
+++ b/baselines/reference/ts4.2/test.d.ts
@@ -1,0 +1,74 @@
+/// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+export class C {
+    protected get p(): number;
+    protected set p(value: number);
+    public get q(): string;
+    private set r(value: boolean);
+}
+// hi, this should still be there
+export namespace N {
+    abstract class D {
+        /**
+         * @readonly
+         * @memberof BlobLeaseClient
+         * @type {number}
+         */
+        get p(): number;
+        /** preserve this too */
+        set p(value: number);
+        get q();
+        abstract set r(value: boolean);
+    }
+}
+/** is this a single-line comment? */
+import type { C as CD } from "./src/test";
+/*preserve it */
+import type { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import type { C as CD5 } from "./src/test";
+import { C as CD4 } from "./src/test";
+/*preserve it */
+export type { CD2, CD3 };
+/*this too */
+export type { CD5 };
+export { CD4 };
+/*preserve it */
+export type { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export type { C as CD9 } from "./src/test";
+export { C as CD8 } from "./src/test";
+// another comment
+export * as rex from "./src/test";
+export interface E {
+    a: number;
+    b: number;
+}
+/// is this a single-line comment?
+export type F = Omit<E, 'a'>;
+export class G {
+    #private;
+}
+export class H extends G {
+    #private;
+}
+export interface I extends Omit<E, 'a'> {
+    version: number;
+}
+declare function guardIsString(val: any): val is string;
+/** side-effects! */
+declare function assertIsString(val: any, msg?: string): asserts val is string;
+declare function assert(val: any, msg?: string): asserts val;
+type J = [
+    foo: string,
+    bar: number,
+    ...arr: boolean[]
+];
+export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts4.3/src/test.d.ts
+++ b/baselines/reference/ts4.3/src/test.d.ts
@@ -1,0 +1,21 @@
+export class C {
+    get p(): number;
+    set p(value: number);
+    get q(): string;
+    set r(value: boolean);
+}
+export namespace N {
+    class D {
+        get p(): number;
+        set p(value: number);
+        get q(): string;
+        set r(value: boolean);
+    }
+}
+export type { C as DetectiveComics };
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Omit<E, 'a'>;

--- a/baselines/reference/ts4.3/test.d.ts
+++ b/baselines/reference/ts4.3/test.d.ts
@@ -1,0 +1,74 @@
+/// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+export class C {
+    protected get p(): number;
+    protected set p(value: number);
+    public get q(): string;
+    private set r(value: boolean);
+}
+// hi, this should still be there
+export namespace N {
+    abstract class D {
+        /**
+         * @readonly
+         * @memberof BlobLeaseClient
+         * @type {number}
+         */
+        get p(): number;
+        /** preserve this too */
+        set p(value: number);
+        get q();
+        abstract set r(value: boolean);
+    }
+}
+/** is this a single-line comment? */
+import type { C as CD } from "./src/test";
+/*preserve it */
+import type { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import type { C as CD5 } from "./src/test";
+import { C as CD4 } from "./src/test";
+/*preserve it */
+export type { CD2, CD3 };
+/*this too */
+export type { CD5 };
+export { CD4 };
+/*preserve it */
+export type { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export type { C as CD9 } from "./src/test";
+export { C as CD8 } from "./src/test";
+// another comment
+export * as rex from "./src/test";
+export interface E {
+    a: number;
+    b: number;
+}
+/// is this a single-line comment?
+export type F = Omit<E, 'a'>;
+export class G {
+    #private;
+}
+export class H extends G {
+    #private;
+}
+export interface I extends Omit<E, 'a'> {
+    version: number;
+}
+declare function guardIsString(val: any): val is string;
+/** side-effects! */
+declare function assertIsString(val: any, msg?: string): asserts val is string;
+declare function assert(val: any, msg?: string): asserts val;
+type J = [
+    foo: string,
+    bar: number,
+    ...arr: boolean[]
+];
+export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts4.4/src/test.d.ts
+++ b/baselines/reference/ts4.4/src/test.d.ts
@@ -1,0 +1,21 @@
+export class C {
+    get p(): number;
+    set p(value: number);
+    get q(): string;
+    set r(value: boolean);
+}
+export namespace N {
+    class D {
+        get p(): number;
+        set p(value: number);
+        get q(): string;
+        set r(value: boolean);
+    }
+}
+export type { C as DetectiveComics };
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Omit<E, 'a'>;

--- a/baselines/reference/ts4.4/test.d.ts
+++ b/baselines/reference/ts4.4/test.d.ts
@@ -1,0 +1,74 @@
+/// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+export class C {
+    protected get p(): number;
+    protected set p(value: number);
+    public get q(): string;
+    private set r(value: boolean);
+}
+// hi, this should still be there
+export namespace N {
+    abstract class D {
+        /**
+         * @readonly
+         * @memberof BlobLeaseClient
+         * @type {number}
+         */
+        get p(): number;
+        /** preserve this too */
+        set p(value: number);
+        get q();
+        abstract set r(value: boolean);
+    }
+}
+/** is this a single-line comment? */
+import type { C as CD } from "./src/test";
+/*preserve it */
+import type { C as CD2, C as CD3 } from "./src/test";
+/*this too */
+import type { C as CD5 } from "./src/test";
+import { C as CD4 } from "./src/test";
+/*preserve it */
+export type { CD2, CD3 };
+/*this too */
+export type { CD5 };
+export { CD4 };
+/*preserve it */
+export type { C as CD6, C as CD7 } from "./src/test";
+/*this too */
+export type { C as CD9 } from "./src/test";
+export { C as CD8 } from "./src/test";
+// another comment
+export * as rex from "./src/test";
+export interface E {
+    a: number;
+    b: number;
+}
+/// is this a single-line comment?
+export type F = Omit<E, 'a'>;
+export class G {
+    #private;
+}
+export class H extends G {
+    #private;
+}
+export interface I extends Omit<E, 'a'> {
+    version: number;
+}
+declare function guardIsString(val: any): val is string;
+/** side-effects! */
+declare function assertIsString(val: any, msg?: string): asserts val is string;
+declare function assert(val: any, msg?: string): asserts val;
+type J = [
+    foo: string,
+    bar: number,
+    ...arr: boolean[]
+];
+export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts4.5/src/test.d.ts
+++ b/baselines/reference/ts4.5/src/test.d.ts
@@ -1,0 +1,21 @@
+export class C {
+    get p(): number;
+    set p(value: number);
+    get q(): string;
+    set r(value: boolean);
+}
+export namespace N {
+    class D {
+        get p(): number;
+        set p(value: number);
+        get q(): string;
+        set r(value: boolean);
+    }
+}
+export type { C as DetectiveComics };
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Omit<E, 'a'>;

--- a/baselines/reference/ts4.5/test.d.ts
+++ b/baselines/reference/ts4.5/test.d.ts
@@ -1,0 +1,71 @@
+/// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+export class C {
+    protected get p(): number;
+    protected set p(value: number);
+    public get q(): string;
+    private set r(value: boolean);
+}
+// hi, this should still be there
+export namespace N {
+    abstract class D {
+        /**
+         * @readonly
+         * @memberof BlobLeaseClient
+         * @type {number}
+         */
+        get p(): number;
+        /** preserve this too */
+        set p(value: number);
+        get q();
+        abstract set r(value: boolean);
+    }
+}
+/** is this a single-line comment? */
+import type { C as CD } from "./src/test";
+/** preserve it */
+import { type C as CD2, type C as CD3 } from "./src/test";
+/** this too */
+import { C as CD4, type C as CD5 } from "./src/test";
+/** preserve it */
+export { type CD2, type CD3 };
+/** this too */
+export { CD4, type CD5 };
+/** preserve it */
+export { type C as CD6, type C as CD7 } from "./src/test";
+/** this too */
+export { C as CD8, type C as CD9 } from "./src/test";
+// another comment
+export * as rex from "./src/test";
+export interface E {
+    a: number;
+    b: number;
+}
+/// is this a single-line comment?
+export type F = Omit<E, 'a'>;
+export class G {
+    #private;
+}
+export class H extends G {
+    #private;
+}
+export interface I extends Omit<E, 'a'> {
+    version: number;
+}
+declare function guardIsString(val: any): val is string;
+/** side-effects! */
+declare function assertIsString(val: any, msg?: string): asserts val is string;
+declare function assert(val: any, msg?: string): asserts val;
+type J = [
+    foo: string,
+    bar: number,
+    ...arr: boolean[]
+];
+export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};
+export type IR = IteratorResult<number, string>;

--- a/baselines/reference/ts4.6/src/test.d.ts
+++ b/baselines/reference/ts4.6/src/test.d.ts
@@ -1,0 +1,21 @@
+export class C {
+    get p(): number;
+    set p(value: number);
+    get q(): string;
+    set r(value: boolean);
+}
+export namespace N {
+    class D {
+        get p(): number;
+        set p(value: number);
+        get q(): string;
+        set r(value: boolean);
+    }
+}
+export type { C as DetectiveComics };
+export type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+export interface E {
+    a: number;
+    b: number;
+}
+export type F = Omit<E, 'a'>;

--- a/baselines/reference/ts4.6/test.d.ts
+++ b/baselines/reference/ts4.6/test.d.ts
@@ -1,0 +1,71 @@
+/// <reference path="./src/test.d.ts" />
+/// <reference types="node" />
+export class C {
+    protected get p(): number;
+    protected set p(value: number);
+    public get q(): string;
+    private set r(value: boolean);
+}
+// hi, this should still be there
+export namespace N {
+    abstract class D {
+        /**
+         * @readonly
+         * @memberof BlobLeaseClient
+         * @type {number}
+         */
+        get p(): number;
+        /** preserve this too */
+        set p(value: number);
+        get q();
+        abstract set r(value: boolean);
+    }
+}
+/** is this a single-line comment? */
+import type { C as CD } from "./src/test";
+/** preserve it */
+import { type C as CD2, type C as CD3 } from "./src/test";
+/** this too */
+import { C as CD4, type C as CD5 } from "./src/test";
+/** preserve it */
+export { type CD2, type CD3 };
+/** this too */
+export { CD4, type CD5 };
+/** preserve it */
+export { type C as CD6, type C as CD7 } from "./src/test";
+/** this too */
+export { C as CD8, type C as CD9 } from "./src/test";
+// another comment
+export * as rex from "./src/test";
+export interface E {
+    a: number;
+    b: number;
+}
+/// is this a single-line comment?
+export type F = Omit<E, 'a'>;
+export class G {
+    #private;
+}
+export class H extends G {
+    #private;
+}
+export interface I extends Omit<E, 'a'> {
+    version: number;
+}
+declare function guardIsString(val: any): val is string;
+/** side-effects! */
+declare function assertIsString(val: any, msg?: string): asserts val is string;
+declare function assert(val: any, msg?: string): asserts val;
+type J = [
+    foo: string,
+    bar: number,
+    ...arr: boolean[]
+];
+export * as default from "./src/test";
+export declare type Asserts<T> = (val: unknown) => asserts val is T;
+export declare const foo: {
+    bar: {
+        baz: <T>(val: unknown) => asserts val is T;
+    };
+};
+export type IR = IteratorResult<number, string>;

--- a/index.test.js
+++ b/index.test.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const semver = require("semver");
 
 describe("main", () => {
-  const tsVersions = ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0"];
+  const tsVersions = ["3.4", "3.5", "3.6", "3.7", "3.8", "3.9", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6"];
 
   if (fs.existsSync(`baselines/local`)) {
     sh.rm("-r", `baselines/local`);


### PR DESCRIPTION
This PR adds tests for TS 4.1 to 4.6 as requested in https://github.com/sandersn/downlevel-dts/pull/67#discussion_r815238345. The test baselines for TS 4.1 to 4.4 are identical to those of TS 4.0. The test baselines for TS 4.5 and 4.6 are identical to the source files in `./test/*` because no downleveling is necessary.