### PR TITLE
Downlevel Awaited

### DIFF
--- a/baselines/reference/ts3.4/test.d.ts
+++ b/baselines/reference/ts3.4/test.d.ts
@@ -69,3 +69,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts3.5/test.d.ts
+++ b/baselines/reference/ts3.5/test.d.ts
@@ -69,3 +69,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts3.6/test.d.ts
+++ b/baselines/reference/ts3.6/test.d.ts
@@ -71,3 +71,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts3.7/test.d.ts
+++ b/baselines/reference/ts3.7/test.d.ts
@@ -71,3 +71,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts3.8/test.d.ts
+++ b/baselines/reference/ts3.8/test.d.ts
@@ -72,3 +72,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts3.9/test.d.ts
+++ b/baselines/reference/ts3.9/test.d.ts
@@ -72,3 +72,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts4.0/test.d.ts
+++ b/baselines/reference/ts4.0/test.d.ts
@@ -72,3 +72,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts4.1/test.d.ts
+++ b/baselines/reference/ts4.1/test.d.ts
@@ -72,3 +72,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts4.2/test.d.ts
+++ b/baselines/reference/ts4.2/test.d.ts
@@ -72,3 +72,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts4.3/test.d.ts
+++ b/baselines/reference/ts4.3/test.d.ts
@@ -72,3 +72,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts4.4/test.d.ts
+++ b/baselines/reference/ts4.4/test.d.ts
@@ -72,3 +72,6 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = T extends null | undefined ? T : T extends object & {
+    then(onfulfilled: infer F): any;
+} ? F extends ((value: infer V, ...args: any) => any) ? K<V> : never : T;

--- a/baselines/reference/ts4.5/test.d.ts
+++ b/baselines/reference/ts4.5/test.d.ts
@@ -69,3 +69,4 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = Awaited<Promise<T>>;

--- a/baselines/reference/ts4.6/test.d.ts
+++ b/baselines/reference/ts4.6/test.d.ts
@@ -69,3 +69,4 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = Awaited<Promise<T>>;

--- a/baselines/reference/ts4.7/test.d.ts
+++ b/baselines/reference/ts4.7/test.d.ts
@@ -69,3 +69,4 @@ export declare const foo: {
     };
 };
 export type IR = IteratorResult<number, string>;
+export type K<T> = Awaited<Promise<T>>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "downlevel-dts",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "downlevel-dts",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.2",
         "shelljs": "^0.8.3",
-        "typescript": "^4.7.0-dev.20220425"
+        "typescript": "next"
       },
       "bin": {
         "downlevel-dts": "index.js"

--- a/test/test.d.ts
+++ b/test/test.d.ts
@@ -75,3 +75,5 @@ export declare const foo: {
 };
 
 export type IR = IteratorResult<number, string>;
+
+export type K<T> = Awaited<Promise<T>>;


### PR DESCRIPTION
Typescript 4.5 has introduced the [Awaited](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-5.html#the-awaited-type-and-promise-improvements) type, which recursively extracts the value inside a promise.

